### PR TITLE
CLAS-305: Updating i18next cookie options

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -58,6 +58,11 @@ const config: Config = {
     name: process.env.SESSION_NAME ?? "",
     resave: false,
     saveUninitialized: false,
+    cookie : {
+      secure: process.env.NODE_ENV === "production",
+      httpOnly: true,
+      sameSite: 'lax'
+    }
   },
   app: {
     port: Number(process.env.PORT ?? DEFAULT_PORT),

--- a/src/scripts/helpers/i18nLoader.ts
+++ b/src/scripts/helpers/i18nLoader.ts
@@ -35,7 +35,8 @@ export function initializeI18nextSync(): void {
         lookupQuerystring: 'lng',
         lookupCookie: 'i18next',
         caches: ['cookie'],
-        cookieSecure: false
+        cookieSecure: process.env.NODE_ENV === 'production',
+        cookieHttpOnly: true
       },
 
       ns: Object.keys(en),

--- a/src/types/config-types.ts
+++ b/src/types/config-types.ts
@@ -14,11 +14,18 @@ export interface CsrfConfig {
   httpOnly: boolean;
 }
 
+export interface SessionCookieConfig {
+  secure: boolean;
+  httpOnly: boolean;
+  sameSite: 'lax' | 'strict' | 'none';
+}
+
 export interface SessionConfig {
   secret: string;
   name: string;
   resave: boolean;
   saveUninitialized: boolean;
+  cookie: SessionCookieConfig;
 }
 
 export interface PathsConfig {


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/CLAS-305)

## What changed and Why?

Updating i18next cookie options to set:
- secure to `true` (production only)
- http-only to `true`

Updating sessionId cookie options to set:
- secure to `true` (production only)
- http-only to `true`
- same-site to `lax`

<img width="956" height="71" alt="Screenshot 2026-04-16 at 11 44 19" src="https://github.com/user-attachments/assets/759e7365-fcbf-444f-99be-ac031f93a068" />

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.