### PR TITLE
Catching syntax error when unable to parse UUID in url.

### DIFF
--- a/src/helpers/errorHandler.ts
+++ b/src/helpers/errorHandler.ts
@@ -85,6 +85,9 @@ function extractErrorMessage(error: unknown): string {
 export function processError(error: unknown, context: string): Error {
   const message = extractErrorMessage(error);
   devError(`Error ${context}: ${message}`);
+  if (error instanceof SyntaxError) {
+    return new createHttpError.BadRequest(message);
+  }
   return new Error(message, { cause: error });
 }
 

--- a/tests/playwright/tests/internal-server-error-page.spec.ts
+++ b/tests/playwright/tests/internal-server-error-page.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '../fixtures/index.js';
+import { claim2Id } from "#tests/playwright/factories/handlers/api.js";
 
 test('internal server error page should have the correct title', async ({ page }) => {
-	const response = await page.goto('/claims/2');
+	const response = await page.goto(`/claims/${claim2Id}`);
 
   if (!response) {
     throw new Error('No response returned from page.goto');

--- a/tests/unit/src/controllers/claims/viewClaimControllerTest.spec.ts
+++ b/tests/unit/src/controllers/claims/viewClaimControllerTest.spec.ts
@@ -80,6 +80,21 @@ describe("View Claim Controller", () => {
       expect(next.firstCall.args[0].message).to.include("not found");
     });
 
+    it("should return 400 when claim ID is not a UUID", async () => {
+      req = {
+        path: "/claims/not-a-uuid",
+        params: { claimId: "not-a-uuid" }
+      };
+
+      await viewClaimPage(req as Request, res as Response, next);
+
+      expect(claimServiceStub.notCalled).to.be.true;
+
+      expect(next.calledOnce).to.be.true;
+      expect(next.firstCall.args[0]).to.be.instanceOf(HttpError);
+      expect(next.firstCall.args[0].status).to.equal(400);
+    });
+
     it("should delegate API errors to Express error handling middleware with user-friendly message", async () => {
       // Arrange
       const error = new Error("API Error");

--- a/tests/unit/src/helpers/errorHandler.spec.ts
+++ b/tests/unit/src/helpers/errorHandler.spec.ts
@@ -12,6 +12,7 @@ import sinon from "sinon";
 import { ApiError } from "#src/types/api-types.js";
 import { AxiosError } from "axios";
 import { ApiErrorResponse } from "#src/generated/claim-api/index.js";
+import { HttpError } from "http-errors";
 
 describe("errorHandler", () => {
   beforeEach(() => {
@@ -46,6 +47,14 @@ describe("errorHandler", () => {
       assert(result instanceof Error);
       assert.strictEqual(result.message, "{\"foo\":\"bar\"}");
       assert.strictEqual(result.cause, inputError);
+    });
+
+    it("returns 400 Error when syntax error", () => {
+      const inputError = new SyntaxError("could not parse UUID string");
+      const result = processError(inputError, "doing something");
+      assert(result instanceof HttpError);
+      assert.strictEqual(result.message, "could not parse UUID string");
+      assert.strictEqual(result.status, 400);
     });
   });
 


### PR DESCRIPTION
- Fix application error disclosure ZAP issue
- Fairly non-issue in this case but not worth ignoring the rule in general
- If url param for claim ID cannot be parsed as a UUID, we catch the SyntaxError and return a 400 with the "Sorry, there is a problem with the service" page

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.